### PR TITLE
handle mouse up when not over button on emulator.

### DIFF
--- a/boards/parts/controller/emulator/src/emulator.cpp
+++ b/boards/parts/controller/emulator/src/emulator.cpp
@@ -4841,6 +4841,8 @@ namespace otto::board {
         } else {
           keyrelease(k);
         }
+      } else {
+        keyrelease(k); //without this, if the mouse leaves the button area while MOUSE_DOWN the button stays active.
       }
     };
 


### PR DESCRIPTION
fixes issue where if you mouse_down -> move out of button area -> mouse_up, the button stays active.